### PR TITLE
Revert "build(deps-dev): update wheel requirement from ~=0.45 to ~=0.46"

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,4 +24,4 @@ flake8-requirements == 2.2.1
 flake8-string-format == 0.3.0
 flake8-variables-names == 0.0.6
 twine == 6.1.0
-wheel ~= 0.46
+wheel ~= 0.45


### PR DESCRIPTION
as wheel 0.46 got yanked

This reverts commit dc3cb3d7fd1b4bb696fa05b24894256060036800.